### PR TITLE
Waveshare 2.2 Bugs and features update

### DIFF
--- a/e-Paper/RaspberryPi_JetsonNano/python/examples/keymaps.py
+++ b/e-Paper/RaspberryPi_JetsonNano/python/examples/keymaps.py
@@ -1,6 +1,7 @@
 # keymaps
 
 # Mapping of characters when Shift is active
+# Note: hyphen is weird, there are at least three different hyphen characters
 shift_mapping = {
     '1': '!',
     '2': '@',
@@ -12,7 +13,9 @@ shift_mapping = {
     '8': '*',
     '9': '(',
     '0': ')',
-    '-': '_',
+    chr(45): '_',
+    chr(8208): '_',
+    chr(8722): '_',
     '=': '+',
     '`': '~',
     'q': 'Q',
@@ -46,4 +49,7 @@ shift_mapping = {
     ',': '<',
     '.': '>',
     '/': '?',
+    '[':'{',
+    ']':'}',
+    '\\':'|',
 }

--- a/e-Paper/RaspberryPi_JetsonNano/python/examples/zerowriter.py
+++ b/e-Paper/RaspberryPi_JetsonNano/python/examples/zerowriter.py
@@ -548,6 +548,13 @@ class ZeroWriter:
             self.input_content = self.input_content[:self.cursor_position - 1] + self.input_content[self.cursor_position:]
             self.cursor_position -= 1  # Move the cursor back
             #self.needs_input_update = True
+        #No characters on the line, move up to previous line
+        elif len(self.previous_lines) > 0:
+            self.input_content = ""
+            self.input_content = self.previous_lines[len(self.previous_lines)-1]
+            self.previous_lines.pop(len(self.previous_lines)-1)
+            self.cursor_position = len(self.input_content)
+            self.needs_display_update = True
 
     def handle_key_down(self, e):
         if e.name == 'shift': #if shift is released
@@ -637,7 +644,7 @@ class ZeroWriter:
         if e.name == "esc":
             self.show_menu()
 
-        if e.name== "down" or e.name== "right" and display_updating==False:
+        if e.name== "down" or e.name== "right" and self.display_updating==False:
           self.scrollindex = self.scrollindex - 1
           if self.scrollindex < 1:
                 self.scrollindex = 1
@@ -646,7 +653,7 @@ class ZeroWriter:
           time.sleep(delay)
           
 
-        if e.name== "up" or e.name== "left" and display_updating==False:
+        if e.name== "up" or e.name== "left" and self.display_updating==False:
           self.scrollindex = self.scrollindex + 1
           if self.scrollindex > round(len(self.previous_lines)/self.lines_on_screen+1):
                 self.scrollindex = round(len(self.previous_lines)/self.lines_on_screen+1)


### PR DESCRIPTION
Issues fixed in this request:
- Arrow keys cause a crash
- Braces and Pipe cause a crash
- Underscore causes a crash
- Backspaces should go to previous line
- CTRL+S does not save current line
- Very long words cause newline problems
- Added key repeat (this also moves input to on key down)
- Zerowriter uses 100% cpu at all times
- CTRL+S should save cache.txt as well
- Zerowriter can hang during CTRL+R while in text editor
- Add CTRL+backspace shortcut to delete a whole word